### PR TITLE
hotfix/UC10-Aanpassen-product-aantal

### DIFF
--- a/Grocery.App/Views/GroceryListItemsView.xaml
+++ b/Grocery.App/Views/GroceryListItemsView.xaml
@@ -38,14 +38,25 @@
                                 <ColumnDefinition Width="20"/>
                                 <ColumnDefinition Width="20"/>
                             </Grid.ColumnDefinitions>
+                            <Grid.RowDefinitions>
+                                <RowDefinition Height="20" />
+                            </Grid.RowDefinitions>
                             <Label Grid.Column="0" Text="{Binding Product.Name}" VerticalOptions="Center"/>
                             <Label Grid.Column="1" Text="{Binding Amount}" VerticalOptions="Center" HorizontalOptions="End" Margin="0,0,10,0"/>
-                            <Grid Grid.Column="2">
-                                <Image Source="plus.png" WidthRequest="15" HeightRequest="15"/>
-                            </Grid>
-                            <Grid Grid.Column="3">
-                                <Image Source="min.png" WidthRequest="15" HeightRequest="15"/>
-                            </Grid>
+                            <Image Grid.Column="2" Source="plus.png" WidthRequest="15" HeightRequest="15" Aspect="AspectFit">
+                                <Image.GestureRecognizers>
+                                    <TapGestureRecognizer
+                                        Command="{Binding BindingContext.IncreaseAmountCommand, Source={RelativeSource AncestorType={x:Type ContentPage}}}"
+                                        CommandParameter="{Binding Product.Id}" />
+                                </Image.GestureRecognizers>
+                            </Image>
+                            <Image Grid.Column="3" Source="min.png" WidthRequest="15" HeightRequest="15" Aspect="AspectFit">
+                                <Image.GestureRecognizers>
+                                    <TapGestureRecognizer
+                                        Command="{Binding BindingContext.DecreaseAmountCommand, Source={RelativeSource AncestorType={x:Type ContentPage}}}"
+                                        CommandParameter="{Binding Product.Id}" />
+                                </Image.GestureRecognizers>
+                            </Image>
                         </Grid>
                     </DataTemplate>
                 </CollectionView.ItemTemplate>

--- a/Grocery.Core/Models/GroceryListItem.cs
+++ b/Grocery.Core/Models/GroceryListItem.cs
@@ -1,10 +1,14 @@
-﻿namespace Grocery.Core.Models
+﻿using CommunityToolkit.Mvvm.ComponentModel;
+
+namespace Grocery.Core.Models
 {
-    public class GroceryListItem : Model
+    public partial class GroceryListItem : Model
     {
         public int GroceryListId { get; set; }
         public int ProductId { get; set; }
-        public int Amount { get; set; }
+
+        [ObservableProperty]
+        private int amount;
         public GroceryListItem(int id, int groceryListId, int productId, int amount) : base(id, "")
         {
             GroceryListId = groceryListId;


### PR DESCRIPTION
Aanpassen van product hoeveelheid in boodschappenlijst werkte niet.

De onderstaande veranderingen zijn doorgevoerd om dit probleem op te lossen:
- In de add/decrease images een <Image.GestureRecognizers> toegevoegd met Command die de gerelateerde methodes aanroept.
- De Amount-property van het GroceryListItem Model aangepast naar een ObservableProperty, zodat aanpassingen aan de hoeveelheid altijd zichtbaar zijn in de applicatie.